### PR TITLE
Update topics_component.html

### DIFF
--- a/base/templates/base/topics_component.html
+++ b/base/templates/base/topics_component.html
@@ -6,7 +6,7 @@
         <li>
             <a href="{% url 'home' %}" class="active">All <span>{{topics.count}}</span></a>
         </li>
-        {% for topic in topics %}
+        {% for topic in topics|slice:":5" %}
         <li>
             <a href="{% url 'home' %}?q={{topic.name}}">{{topic.name}}<span>{{topic.room_set.all.count}}</span></a>
         </li>


### PR DESCRIPTION
I changed this, because we want to limit the number of all `Topics` in BROWSE TOPICS. So, in the **views.py** file , home definition,  `topics = Topic.objects.all()[0:5]` should be changed to `topics = Topic.objects.all()` in order to show number of `All` topics completely.